### PR TITLE
Change cvvis to cnorm to support tmux

### DIFF
--- a/src/com/walmartlabs/active_status.clj
+++ b/src/com/walmartlabs/active_status.clj
@@ -171,7 +171,7 @@
                       (progress-formatter progress))
                     ansi/reset-font
                     (tput "rc")                             ; restore cursor position
-                    (tput "cvvis")                          ; make cursor visible
+                    (tput "cnorm")                          ; make cursor visible
                     ))
         (catch Throwable t
           (throw (ex-info "Exception updating console status board."


### PR DESCRIPTION
@hlship
It sounds like `cnorm` is the preferred capability to reshow the cursor. tmux in particular doesn't play well with `cvvis`. https://github.com/tmux/tmux/issues/429

And from https://www.gnu.org/software/termutils/manual/termutils-2.0/html_chapter/tput_1.html:
`cnorm   ve      Make cursor normal (undo 'cvvis' & 'civis)'`
