### PR TITLE
Add a simple api which hides the core.async details

### DIFF
--- a/dev-resources/api_demo.clj
+++ b/dev-resources/api_demo.clj
@@ -1,0 +1,119 @@
+(ns api-demo
+  (:use clojure.repl)
+  (:require [clojure.core.async :refer [close! go go-loop timeout <! >! >!! <!! put!]]
+            [com.walmartlabs.active-status.minimal-board :refer [minimal-status-board]]
+            [com.walmartlabs.active-status.api :as api]
+            [com.walmartlabs.active-status :refer :all :as as])
+  (:import [java.util UUID]))
+
+;;-------------------------------
+;; demo
+
+(defn- run-job
+  ([job-id speed count]
+   (run-job job-id speed count :normal false))
+  ([job-id speed count status progress]
+   (go
+     (api/add-job job-id)
+     (api/update-job job-id (-> (UUID/randomUUID) (str " ") set-prefix))
+     (dotimes [i count]
+       (when (= i 0)
+         (api/update-job job-id (str job-id " - started"))
+         (when progress
+           (api/update-job job-id (start-progress count))))
+       (<! (timeout speed))
+       (when (= i 5)
+         (api/update-job job-id (change-status status)))
+       (when-not progress
+         (api/update-job job-id (str job-id " - update " (inc i) "/" count)))
+       (when progress
+         (api/update-job job-id (progress-tick))))
+     (api/update-job job-id (str job-id " - completed " count))
+     (when progress
+       (api/update-job job-id (complete-progress)))
+     (api/stop-job job-id))))
+
+(defn demo
+  ([]
+   (with-output-redirected "out"
+     (let [_ (api/init-status-board (console-status-board))]
+       (api/add-job :overall {:status :success :pinned true})
+       (api/update-job :overall "adding one, two, three")
+       (run-job "one" 100 50)
+       (run-job "two" 500 100 :warning true)
+       (run-job "three" 250 10 :normal true)
+       (api/update-job :overall "first sleep")
+       (Thread/sleep 3000)
+       (api/update-job :overall "adding four, five")
+       (run-job "four" 250 10 :success false)
+       (run-job "five" 2000 30)
+       (api/update-job :overall "second sleep")
+       (Thread/sleep 3000)
+       (run-job "six" 250 100 :error true)
+       (run-job "seven" 10 1000 :normal true)
+       (Thread/sleep 2000)
+       (api/update-job :overall "final (long) sleep")
+       (Thread/sleep 15000)
+       (api/update-job :overall "shutting down!")
+       (Thread/sleep 1000)
+       (api/stop-job :overall)
+       (Thread/sleep 1000)
+       (api/shutdown)))))
+
+(defn progress-job
+  [job-id target delay]
+  (let [job (api/add-job job-id)]
+    (go
+      (job job-id)
+      ;; Uncomment to test per-job progress formatting:
+      #_(job (set-progress-formatter (fn [{:keys [::as/current ::as/target]}]
+                                                         (str " " current "/" target))))
+      (job (start-progress target))
+
+      (dotimes [_ target]
+        (<! (timeout delay))
+        (job (progress-tick)))
+
+      (job (complete-progress))
+      (job (change-status :success))
+      (<! (timeout 100))
+      (api/stop-job job-id))))
+
+(defn simple-job
+  [job-id delay]
+  (let [job (api/add-job job-id)]
+    (go
+      (job (str job-id " ..."))
+      (<! (timeout delay))
+      #_(when (.contains job-id "speed")
+          (binding [*out* *err*] (println "Turbine go boom!"))
+          (throw (RuntimeException. "Turbine failure.")))
+      (job (str job-id " \u2713"))
+      (job (change-status :success))
+      #_(println (Date.) "job" job-id "- completed")
+      (<! (timeout delay))
+      (api/stop-job job-id))))
+
+(defn start-batmobile
+  ([]
+   (start-batmobile (console-status-board)))
+  ([t]
+   (api/init-status-board t)
+   (with-output-redirected "batmobile"
+     (<!! (go
+            (let [channels [(simple-job "Atomic turbines to speed" 2000)
+                            (progress-job "Loading Bat-fuel" 15 250)
+                            (progress-job "Rotating Batmobile platform" 180 10)
+                            (simple-job "Initializing on-board Bat-computer" 1000)
+                            (go
+                              (<! (timeout 1000))
+                              (let [job (add-job t {:status :warning})]
+                                (job "Please fasten your Bat-seatbelts")))]]
+              (doseq [ch channels]
+                (<! ch)                                     ; wait for each sub-job to finish
+                ))))
+     (shutdown! t))))
+
+(comment
+ (demo)
+ (start-batmobile))

--- a/src/com/walmartlabs/active_status/api.clj
+++ b/src/com/walmartlabs/active_status/api.clj
@@ -1,0 +1,57 @@
+(ns com.walmartlabs.active-status.api
+  (:require [clojure.core.async :as async]
+            [clojure.spec :as s]
+            [com.walmartlabs.active-status :as as]))
+
+(def ^:private global-status-board (atom nil))
+
+(def ^:private global-job-channels (atom {}))
+
+(defn active-board? []
+  (not (nil? @global-status-board)))
+
+(defn init-status-board [board]
+  (reset! global-status-board board))
+
+(defn shutdown []
+  (when (active-board?)
+    (as/shutdown! @global-status-board)
+    (reset! global-status-board nil)
+    (reset! global-job-channels {})))
+
+(defn update-job
+  "Update job with id of job-id according to update-payload
+
+   job-id: a string or keyword
+   update-payload: either a String or an update function
+   -  String: will update the :com.walmartlabs.active-status/summary field
+   -  update function: will update job properties (eg. change-status, start-progress)"
+  [job-id update-payload]
+  (when (active-board?)
+    (when-let [ch (get @global-job-channels job-id)]
+      (async/>!! ch update-payload))))
+
+(defn add-job
+  "Add a job with the given job-id and options.
+
+   job-id: a string or keyword
+   options: a map with either of the following properties:
+   - status: keyword; the initial status for the job (:normal, :success, :warning, :error)
+   - pinned: boolean; whether to pin the output of this job to the top of the active list
+
+   Returns a convenience function which wraps update-job with the current job-id.
+   The usage of that function is similar to update-job. See the doc for update-job."
+  ([job-id]
+   (add-job job-id nil))
+  ([job-id options]
+   (when (active-board?)
+     (let [ch (as/add-job @global-status-board options)]
+       (swap! global-job-channels assoc job-id ch)))
+   (partial update-job job-id)))
+
+(defn stop-job [job-id]
+  (when (active-board?)
+    (when-let [ch (get @global-job-channels job-id)]
+      (async/close! ch)
+      (swap! global-job-channels dissoc job-id)))
+  nil)


### PR DESCRIPTION
@hlship 

Also creates a global var for the console, so that the status updates can be treated more like calls to a logger.

I found that the async channels used to create jobs, update jobs, etc are a confusing api. In some cases, job channels are passed from function to function. There is no self-evident way to know what messages a channel is expecting in that case without tracing the call path to find the function which created the channel in the first place, and looking at its doc.
Example:
```
(defn perform-work [status-board-ch job-ch work-data]
  (>! job-ch ?) ; <-- not obvious what to provide here, especially for 
                ;     someone unfamiliar with the library
```
I've also seen cases where the job channel is named not like a channel (`job`, `t`, etc), which makes it even harder to know what is going on.
With the new api:
```
(defn perform-work [job-id work-data]
  (status-api/update-job job-id "Starting work") ; clearer, plus javadocs are available 
```
By hiding the details of the core.async channels, the consumer isn't required to use the async api, if the use case is trivial enough. Some applications might be single-threaded processing of one big chunk of data.

By also making a global status-board  -- I know, global state, but the channels are already mutable state, so... -- it makes the api feel more like a logger, which I think is a good similarity. In one case where I used the library, I recall feeling like passing all the active-status channels around really added to the cognitive overhead of what was going on, rather than just simply enhancing the transparency of the application's progress.